### PR TITLE
Implement alternate subcommands for stacky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 src/stacky/__pycache__
 
 bazel-*
+.stacky
+.codex

--- a/README.md
+++ b/README.md
@@ -179,8 +179,25 @@ List of parameters for each sections:
  * change_to_adopted: boolean with a default value of `False`, when set to `True` `stacky` will change the current branch to the adopted one.
  * share_ssh_session: boolean with a default value of `False`, when set to `True` `stacky` will create a shared `ssh` session to the `github.com` server. This is useful when you are pushing a stack of diff and you have some kind of 2FA on your ssh key like the ed25519-sk.
  * remote_name: string with a default value of `origin`, sets the default git remote used by commands such as `push` and `update`. You can still override it per command with `--remote-name` / `-r`.
+ * git_command: string with a default value of `git`, sets the fallback command prefix Stacky uses for internal git operations. For example, `git_command = alternategit cache` makes Stacky run `alternategit cache status` instead of `git status`. You can also override this per invocation with `--git-command`.
  * use_worktree: boolean with a default value of `False`, when set to `True` branch checkout and branch creation use dedicated git worktrees.
  * worktree_root: string with a default value of `.stacky/worktrees`, controls where stacky stores managed worktrees.
+
+### git_commands
+
+Use this section to override individual git subcommands. The replacement command is shell-split and Stacky appends the regular arguments for that git subcommand.
+
+```
+[git_commands]
+fetch = mygit fetch fromcache
+push = myothergit push params
+```
+
+With this config, `git fetch origin` becomes `mygit fetch fromcache origin`, and `git push -f origin branch:branch` becomes `myothergit push params -f origin branch:branch`. Per-subcommand overrides can also be provided per invocation with repeated `--git-command` flags:
+
+```
+stacky --git-command 'fetch=mygit fetch fromcache' --git-command 'push=myothergit push params' update
+```
 
 ## Shell wrapper for worktree auto-cd
 

--- a/src/stacky/stacky.py
+++ b/src/stacky/stacky.py
@@ -164,6 +164,8 @@ class StackyConfig:
     change_to_adopted: bool = False
     share_ssh_session: bool = False
     remote_name: Optional[str] = None
+    git_command: Optional[str] = None
+    git_commands: Dict[str, str] = dataclasses.field(default_factory=dict)
     use_worktree: bool = False
     worktree_root: Optional[str] = None
 
@@ -176,11 +178,17 @@ class StackyConfig:
             self.change_to_adopted = rawconfig.getboolean("UI", "change_to_adopted", fallback=self.change_to_adopted)
             self.share_ssh_session = rawconfig.getboolean("UI", "share_ssh_session", fallback=self.share_ssh_session)
             self.remote_name = rawconfig.get("UI", "remote_name", fallback=self.remote_name)
+            self.git_command = rawconfig.get("UI", "git_command", fallback=self.git_command)
             self.use_worktree = rawconfig.getboolean("UI", "use_worktree", fallback=self.use_worktree)
             self.worktree_root = rawconfig.get("UI", "worktree_root", fallback=self.worktree_root)
+        if rawconfig.has_section("git_commands"):
+            for command, replacement in rawconfig.items("git_commands"):
+                self.git_commands[command] = replacement
 
 
 CONFIG: Optional["StackyConfig"] = None
+GIT_COMMAND_PREFIX: List[str] = ["git"]
+GIT_SUBCOMMAND_PREFIXES: Dict[str, List[str]] = {}
 
 
 def get_config() -> StackyConfig:
@@ -480,6 +488,98 @@ def _check_returncode(sp: subprocess.CompletedProcess, cmd: CmdArgs):
         die("Exited with status {}: {}. Stderr was:\n{}", rc, shlex.join(cmd), stderr)
 
 
+def set_git_command(command: Optional[str]):
+    global GIT_COMMAND_PREFIX
+    if not command:
+        GIT_COMMAND_PREFIX = ["git"]
+        return
+    try:
+        parts = shlex.split(command)
+    except ValueError as e:
+        die("Invalid git_command {!r}: {}", command, e)
+    if not parts:
+        die("Invalid git_command {!r}: expected a command", command)
+    GIT_COMMAND_PREFIX = parts
+
+
+def set_git_subcommand_commands(commands: Dict[str, str]):
+    global GIT_SUBCOMMAND_PREFIXES
+    prefixes: Dict[str, List[str]] = {}
+    for subcommand, command in commands.items():
+        try:
+            parts = shlex.split(command)
+        except ValueError as e:
+            die("Invalid git command override for {!r}: {}", subcommand, e)
+        if not parts:
+            die("Invalid git command override for {!r}: expected a command", subcommand)
+        prefixes[subcommand] = parts
+    GIT_SUBCOMMAND_PREFIXES = prefixes
+
+
+def configure_git_commands(default_command: Optional[str], subcommand_commands: Dict[str, str]):
+    set_git_command(default_command)
+    set_git_subcommand_commands(subcommand_commands)
+
+
+def parse_git_command_overrides(values: Optional[List[str]]) -> Tuple[Optional[str], Dict[str, str]]:
+    default_command: Optional[str] = None
+    subcommand_commands: Dict[str, str] = {}
+    for value in values or []:
+        subcommand, sep, command = value.partition("=")
+        if sep and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", subcommand):
+            subcommand_commands[subcommand] = command
+        else:
+            default_command = value
+    return default_command, subcommand_commands
+
+
+def _split_git_command(cmd: CmdArgs) -> Optional[Tuple[List[str], str, List[str]]]:
+    if not cmd or cmd[0] != "git":
+        return None
+
+    global_args: List[str] = []
+    i = 1
+    while i < len(cmd):
+        arg = cmd[i]
+        if arg == "--":
+            return None
+        if arg in ("-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--html-path"):
+            if i + 1 >= len(cmd):
+                return None
+            global_args.extend([arg, cmd[i + 1]])
+            i += 2
+            continue
+        if (
+            arg.startswith("--git-dir=")
+            or arg.startswith("--work-tree=")
+            or arg.startswith("--namespace=")
+            or arg.startswith("--exec-path=")
+            or arg.startswith("-c")
+        ):
+            global_args.append(arg)
+            i += 1
+            continue
+        if arg.startswith("-"):
+            global_args.append(arg)
+            i += 1
+            continue
+        return global_args, arg, list(cmd[i + 1 :])
+    return None
+
+
+def resolve_command(cmd: CmdArgs) -> CmdArgs:
+    parsed = _split_git_command(cmd)
+    if parsed is None:
+        return cmd
+    global_args, subcommand, subcommand_args = parsed
+    if subcommand in GIT_SUBCOMMAND_PREFIXES:
+        prefix = GIT_SUBCOMMAND_PREFIXES[subcommand]
+        return CmdArgs(prefix[0:1] + global_args + prefix[1:] + subcommand_args)
+    if cmd and cmd[0] == "git":
+        return CmdArgs(GIT_COMMAND_PREFIX + list(cmd[1:]))
+    return cmd
+
+
 def _existing_worktree_from_git_error(stderr: str, branch: BranchName) -> Optional[str]:
     match = re.search(r"fatal: '([^']+)' is already (?:used by worktree|checked out) at '([^']+)'", stderr)
     if match is None:
@@ -490,6 +590,7 @@ def _existing_worktree_from_git_error(stderr: str, branch: BranchName) -> Option
 
 
 def run_multiline(cmd: CmdArgs, *, check: bool = True, null: bool = True, out: bool = False) -> Optional[str]:
+    cmd = resolve_command(cmd)
     debug("Running: {}", shlex.join(cmd))
     sys.stdout.flush()
     sys.stderr.flush()
@@ -1118,6 +1219,7 @@ def _list_spare_worktree_paths(root: str, entries: List[WorktreeEntry]) -> List[
 
 
 def _run_worktree_branch_command(cmd: CmdArgs, branch: BranchName) -> Optional[str]:
+    cmd = resolve_command(cmd)
     debug("Running: {}", shlex.join(cmd))
     sys.stdout.flush()
     sys.stderr.flush()
@@ -2244,6 +2346,15 @@ def main():
             default=None,
             help="name of the git remote where branches will be pushed",
         )
+        parser.add_argument(
+            "--git-command",
+            action="append",
+            default=[],
+            help=(
+                'command prefix to use instead of "git", or SUBCOMMAND=COMMAND to override one git subcommand '
+                "(repeatable)"
+            ),
+        )
 
         subparsers = parser.add_subparsers(required=True, dest="command")
 
@@ -2483,6 +2594,9 @@ def main():
 
         args = parser.parse_args()
         logging.basicConfig(format=_LOGGING_FORMAT, level=LOGLEVELS[args.log_level], force=True)
+        cli_git_command, cli_git_commands = parse_git_command_overrides(args.git_command)
+        if cli_git_command is not None or cli_git_commands:
+            configure_git_commands(cli_git_command, cli_git_commands)
 
         if args.command == "shell":
             args.func(args)
@@ -2510,6 +2624,9 @@ def main():
         global CONFIG
         CONFIG = read_config()
         config = get_config()
+        git_commands = dict(config.git_commands)
+        git_commands.update(cli_git_commands)
+        configure_git_commands(cli_git_command if cli_git_command is not None else config.git_command, git_commands)
         if args.remote_name is None:
             args.remote_name = config.remote_name or "origin"
 

--- a/src/stacky/stacky_test.py
+++ b/src/stacky/stacky_test.py
@@ -129,6 +129,108 @@ class TestWorktreeSupport(unittest.TestCase):
             os.unlink(path)
         self.assertEqual(cfg.remote_name, "upstream")
 
+    def test_read_one_config_git_commands(self):
+        cfg = stacky_module.StackyConfig()
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write(
+                "[UI]\n"
+                "git_command = alternategit cache\n"
+                "[git_commands]\n"
+                "fetch = mygit fetch fromcache\n"
+                "push = myothergit push params\n"
+            )
+            path = f.name
+        try:
+            cfg.read_one_config(path)
+        finally:
+            os.unlink(path)
+        self.assertEqual(cfg.git_command, "alternategit cache")
+        self.assertEqual(cfg.git_commands["fetch"], "mygit fetch fromcache")
+        self.assertEqual(cfg.git_commands["push"], "myothergit push params")
+
+    def test_resolve_command_replaces_git_with_configured_prefix(self):
+        stacky_module.configure_git_commands("alternategit cache", {})
+        try:
+            self.assertEqual(
+                stacky_module.resolve_command(stacky_module.CmdArgs(["git", "fetch", "origin"])),
+                ["alternategit", "cache", "fetch", "origin"],
+            )
+            self.assertEqual(
+                stacky_module.resolve_command(stacky_module.CmdArgs(["gh", "auth", "status"])),
+                ["gh", "auth", "status"],
+            )
+        finally:
+            stacky_module.configure_git_commands(None, {})
+
+    def test_resolve_command_uses_subcommand_override(self):
+        stacky_module.configure_git_commands(
+            None,
+            {
+                "fetch": "mygit fetch fromcache",
+                "push": "myothergit push params",
+            },
+        )
+        try:
+            self.assertEqual(
+                stacky_module.resolve_command(stacky_module.CmdArgs(["git", "fetch", "origin", "--prune"])),
+                ["mygit", "fetch", "fromcache", "origin", "--prune"],
+            )
+            self.assertEqual(
+                stacky_module.resolve_command(
+                    stacky_module.CmdArgs(["git", "push", "-f", "origin", "feature:feature"])
+                ),
+                ["myothergit", "push", "params", "-f", "origin", "feature:feature"],
+            )
+            self.assertEqual(
+                stacky_module.resolve_command(stacky_module.CmdArgs(["git", "status", "--short"])),
+                ["git", "status", "--short"],
+            )
+        finally:
+            stacky_module.configure_git_commands(None, {})
+
+    def test_resolve_command_keeps_global_git_args_before_subcommand_override(self):
+        stacky_module.configure_git_commands(None, {"fetch": "mygit fetch fromcache"})
+        try:
+            self.assertEqual(
+                stacky_module.resolve_command(stacky_module.CmdArgs(["git", "-C", "/repo/wt", "fetch", "origin"])),
+                ["mygit", "-C", "/repo/wt", "fetch", "fromcache", "origin"],
+            )
+        finally:
+            stacky_module.configure_git_commands(None, {})
+
+    def test_parse_git_command_overrides(self):
+        default_command, subcommand_commands = stacky_module.parse_git_command_overrides(
+            [
+                "alternategit cache",
+                "fetch=mygit fetch fromcache",
+                "push=myothergit push params",
+            ]
+        )
+        self.assertEqual(default_command, "alternategit cache")
+        self.assertEqual(
+            subcommand_commands,
+            {
+                "fetch": "mygit fetch fromcache",
+                "push": "myothergit push params",
+            },
+        )
+
+    @mock.patch.object(stacky_module.subprocess, "run")
+    def test_run_multiline_uses_alternate_git_command(self, subprocess_run_mock):
+        subprocess_run_mock.return_value = subprocess.CompletedProcess(
+            args=["alternategit", "cache", "fetch", "origin"],
+            returncode=0,
+            stdout=b"ok\n",
+            stderr=b"",
+        )
+        stacky_module.configure_git_commands("alternategit cache", {})
+        try:
+            self.assertEqual(stacky_module.run(stacky_module.CmdArgs(["git", "fetch", "origin"])), "ok")
+        finally:
+            stacky_module.configure_git_commands(None, {})
+        subprocess_run_mock.assert_called_once()
+        self.assertEqual(subprocess_run_mock.call_args.args[0], ["alternategit", "cache", "fetch", "origin"])
+
     def test_get_gh_repo_parses_https_remote(self):
         with mock.patch.object(stacky_module, "run", side_effect=[None, "https://github.com/org/repo.git"]):
             self.assertEqual(stacky_module.get_gh_repo("upstream"), "org/repo")
@@ -225,6 +327,28 @@ class TestWorktreeSupport(unittest.TestCase):
             stacky_module.BranchName("feature"),
         )
         self.assertEqual(path, "/repo/.stacky/worktrees/checkout-6")
+
+    @mock.patch.object(stacky_module.subprocess, "run")
+    def test_run_worktree_branch_command_uses_alternate_git_command(self, subprocess_run_mock):
+        subprocess_run_mock.return_value = subprocess.CompletedProcess(
+            args=["alternategit", "cache", "worktree", "add", "/wt/feature", "feature"],
+            returncode=0,
+            stdout=b"",
+            stderr=b"",
+        )
+        stacky_module.configure_git_commands("alternategit cache", {})
+        try:
+            path = stacky_module._run_worktree_branch_command(
+                stacky_module.CmdArgs(["git", "worktree", "add", "/wt/feature", "feature"]),
+                stacky_module.BranchName("feature"),
+            )
+        finally:
+            stacky_module.configure_git_commands(None, {})
+        self.assertIsNone(path)
+        self.assertEqual(
+            subprocess_run_mock.call_args.args[0],
+            ["alternategit", "cache", "worktree", "add", "/wt/feature", "feature"],
+        )
 
     def test_get_worktree_root_uses_repo_top_level(self):
         cfg = stacky_module.StackyConfig(use_worktree=True, worktree_root=".stacky/worktrees")


### PR DESCRIPTION
 Instead of using always git fetch/pull/... allow to use alternate
commands for whatever reasons (ie. caching implementation, ...)
